### PR TITLE
Add weak_ptr support in shared_ptr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,15 @@ matrix:
       - <<: *linux
         env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=lasote/conangcc7
       - <<: *linux
+        env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=lasote/conangcc8
+      - <<: *linux
         env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=lasote/conanclang39
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=lasote/conanclang40
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=lasote/conanclang50
+      - <<: *linux
+        env: CONAN_CLANG_VERSIONS=6.0 CONAN_DOCKER_IMAGE=lasote/conanclang60
       - <<: *osx
         osx_image: xcode8.3
         env: CONAN_APPLE_CLANG_VERSIONS=8.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,10 @@ set(TESTS
     unique_ptr_to_array_access
     unique_ptr_to_array_assignment
     unique_ptr_to_array_construction
+    weak_ptr_assignment
+    weak_ptr_construction
+    weak_ptr_modifiers
+    weak_ptr_observers
 )
 
 if(HAVE_SHARED_PTR_TO_ARRAY)

--- a/tests/shared_ptr_access.cpp
+++ b/tests/shared_ptr_access.cpp
@@ -33,15 +33,15 @@ TEST_CASE("shared_ptr get returns correct address", "[shared_ptr][access]") {
 TEST_CASE("shared_ptr dereference via * throws on nullptr",
           "[shared_ptr][dereference][nullptr]") {
     throwing::shared_ptr<int> nothing;
-    REQUIRE_THROWS_AS((*nothing)++, throwing::base_null_ptr_exception);
-    REQUIRE_THROWS_AS((*nothing)++, throwing::null_ptr_exception<int>);
+    REQUIRE_THROWS_AS((*nothing)++, throwing::base_null_ptr_exception&);
+    REQUIRE_THROWS_AS((*nothing)++, throwing::null_ptr_exception<int>&);
 }
 
 TEST_CASE("shared_ptr dereference via -> throws on nullptr",
           "[shared_ptr][dereference][nullptr]") {
     throwing::shared_ptr<Foo> nothing;
-    REQUIRE_THROWS_AS(nothing->foo(), throwing::base_null_ptr_exception);
-    REQUIRE_THROWS_AS(nothing->foo(), throwing::null_ptr_exception<Foo>);
+    REQUIRE_THROWS_AS(nothing->foo(), throwing::base_null_ptr_exception&);
+    REQUIRE_THROWS_AS(nothing->foo(), throwing::null_ptr_exception<Foo>&);
 }
 
 TEST_CASE("type specific shared_ptr exceptions are caught by base exception",

--- a/tests/shared_ptr_to_array.cpp
+++ b/tests/shared_ptr_to_array.cpp
@@ -34,8 +34,8 @@ TEST_CASE("shared_ptr to array: get returns first element",
 TEST_CASE("dereferencing null shared_ptr to array throws",
           "[shared_ptr][array][access]") {
     throwing::shared_ptr<Foo[100]> nothing;
-    REQUIRE_THROWS_AS(nothing[0], throwing::base_null_ptr_exception);
-    REQUIRE_THROWS_AS(nothing[0], throwing::null_ptr_exception<Foo[100]>);
+    REQUIRE_THROWS_AS(nothing[0], throwing::base_null_ptr_exception&);
+    REQUIRE_THROWS_AS(nothing[0], throwing::null_ptr_exception<Foo[100]>&);
 }
 
 TEST_CASE("shared_ptr to array: [0] returns first element",

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -1,0 +1,39 @@
+//          Copyright Claudio Bantaloukas 2017-2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+class TestBaseClass {
+    int dummy_a = 1;
+
+public:
+    int dummy() { return dummy_a; }
+};
+
+class TestDerivedClass : public TestBaseClass {
+    int dummy_b = 2;
+
+public:
+    int dummy() { return dummy_b; }
+};
+
+struct TestBaseClassSimpleDeleter {
+    void operator()(A *p) const { delete p; }
+};
+
+struct TestContentClass {
+    // some data that we want to point to
+    int dummy_ = 3;
+    int dummy() { return dummy_; }
+};
+
+struct TestContainingClass {
+    Contained things;
+};
+
+struct MemoryPositionHelper {
+    // helper for owner_before
+    int m1;
+    int m2;
+    Foo(int a, int b) : m1(a), m2(b) {}
+};

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -18,7 +18,7 @@ public:
 };
 
 struct TestBaseClassSimpleDeleter {
-    void operator()(A *p) const { delete p; }
+    void operator()(TestBaseClass *p) const { delete p; }
 };
 
 struct TestContentClass {
@@ -28,12 +28,12 @@ struct TestContentClass {
 };
 
 struct TestContainingClass {
-    Contained things;
+    TestContentClass things;
 };
 
 struct MemoryPositionHelper {
     // helper for owner_before
     int m1;
     int m2;
-    Foo(int a, int b) : m1(a), m2(b) {}
+    MemoryPositionHelper(int a, int b) : m1(a), m2(b) {}
 };

--- a/tests/unique_ptr_dereference.cpp
+++ b/tests/unique_ptr_dereference.cpp
@@ -16,15 +16,15 @@ struct Foo {
 TEST_CASE("unique_ptr dereference via * throws on nullptr",
           "[unique_ptr][dereference][nullptr]") {
     throwing::unique_ptr<int> nothing;
-    REQUIRE_THROWS_AS((*nothing)++, throwing::base_null_ptr_exception);
-    REQUIRE_THROWS_AS((*nothing)++, throwing::null_ptr_exception<int>);
+    REQUIRE_THROWS_AS((*nothing)++, throwing::base_null_ptr_exception&);
+    REQUIRE_THROWS_AS((*nothing)++, throwing::null_ptr_exception<int>&);
 }
 
 TEST_CASE("unique_ptr dereference via -> throws on nullptr",
           "[unique_ptr][dereference][nullptr]") {
     throwing::unique_ptr<Foo> nothing;
-    REQUIRE_THROWS_AS(nothing->foo(), throwing::base_null_ptr_exception);
-    REQUIRE_THROWS_AS(nothing->foo(), throwing::null_ptr_exception<Foo>);
+    REQUIRE_THROWS_AS(nothing->foo(), throwing::base_null_ptr_exception&);
+    REQUIRE_THROWS_AS(nothing->foo(), throwing::null_ptr_exception<Foo>&);
 }
 
 TEST_CASE("type specific unique_ptr exceptions are caught by base exception",

--- a/tests/unique_ptr_to_array_access.cpp
+++ b/tests/unique_ptr_to_array_access.cpp
@@ -33,8 +33,8 @@ TEST_CASE("unique_ptr to array: get returns first element",
 TEST_CASE("unique_ptr to array: dereferencing nullptr throws",
           "[unique_ptr][array][access][nullptr]") {
     throwing::unique_ptr<Foo[]> nothing;
-    REQUIRE_THROWS_AS(nothing[0], throwing::base_null_ptr_exception);
-    REQUIRE_THROWS_AS(nothing[0], throwing::null_ptr_exception<Foo>);
+    REQUIRE_THROWS_AS(nothing[0], throwing::base_null_ptr_exception&);
+    REQUIRE_THROWS_AS(nothing[0], throwing::null_ptr_exception<Foo>&);
 }
 
 TEST_CASE("unique_ptr to array: [0] returns first element",

--- a/tests/weak_ptr_assignment.cpp
+++ b/tests/weak_ptr_assignment.cpp
@@ -1,0 +1,82 @@
+//          Copyright Claudio Bantaloukas 2017-2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include "test_helpers.h"
+#include <catch.hpp>
+#include <throwing/weak_ptr.hpp>
+
+TEST_CASE("weak_ptr assignment from std::shared_ptr",
+          "[weak_ptr][assignment]") {
+    auto p = std::make_shared<int>(42);
+    throwing::weak_ptr<int> wp;
+    REQUIRE(wp.lock() == nullptr);
+    wp = p;
+    REQUIRE(wp.lock() == p);
+}
+
+TEST_CASE("weak_ptr assignment from std::shared_ptr to derived class",
+          "[weak_ptr][assignment]") {
+    auto p = std::make_shared<TestDerivedClass>(42);
+    throwing::weak_ptr<TestBaseClass> wp;
+    REQUIRE(wp.lock() == nullptr);
+    wp = p;
+    REQUIRE(wp.lock() == p);
+}
+
+TEST_CASE("weak_ptr assignment from throwing::shared_ptr",
+          "[weak_ptr][assignment]") {
+    auto p = throwing::make_shared<int>(42);
+    throwing::weak_ptr<int> wp;
+    REQUIRE(wp.lock() == nullptr);
+    wp = p;
+    REQUIRE(wp.lock() == p);
+}
+
+TEST_CASE("weak_ptr assignment from throwing::shared_ptr to derived class",
+          "[weak_ptr][assignment]") {
+    auto p = throwing::make_shared<TestDerivedClass>();
+    throwing::weak_ptr<TestBaseClass> wp;
+    REQUIRE(wp.lock() == nullptr);
+    wp = p;
+    REQUIRE(wp.lock() == p);
+}
+
+TEST_CASE("weak_ptr assignment from weak_ptr", "[weak_ptr][assignment]") {
+    auto p = throwing::make_shared<int>(42);
+    throwing::weak_ptr<int> wp(p);
+    throwing::weak_ptr<int> wp2;
+    REQUIRE(wp2.lock() == nullptr);
+    wp2 = wp;
+    REQUIRE(wp2.lock() == p);
+}
+
+TEST_CASE("weak_ptr assignment from derived class weak_ptr",
+          "[weak_ptr][assignment]") {
+    auto p = throwing::make_shared<TestDerivedClass>();
+    throwing::weak_ptr<TestDerivedClass> wp(p);
+    throwing::weak_ptr<TestBaseClass> wp2;
+    REQUIRE(wp2.lock() == nullptr);
+    wp2 = wp;
+    REQUIRE(wp2.lock() == p);
+}
+
+TEST_CASE("weak_ptr move assignment", "[weak_ptr][assignment]") {
+    auto p = throwing::make_shared<int>(42);
+    throwing::weak_ptr<int> wp(p);
+    throwing::weak_ptr<int> wp2;
+    REQUIRE(wp2.lock() == nullptr);
+    wp2 = std::move(wp);
+    REQUIRE(wp2.lock() == p);
+}
+
+TEST_CASE("weak_ptr move assignment from derived class weak_ptr",
+          "[weak_ptr][assignment]") {
+    auto p = throwing::make_shared<TestDerivedClass>();
+    throwing::weak_ptr<TestDerivedClass> wp(p);
+    throwing::weak_ptr<TestBaseClass> wp2;
+    REQUIRE(wp2.lock() == nullptr);
+    wp2 = std::move(wp);
+    REQUIRE(wp2.lock() == p);
+}

--- a/tests/weak_ptr_assignment.cpp
+++ b/tests/weak_ptr_assignment.cpp
@@ -5,7 +5,7 @@
 
 #include "test_helpers.h"
 #include <catch.hpp>
-#include <throwing/weak_ptr.hpp>
+#include <throwing/shared_ptr.hpp>
 
 TEST_CASE("weak_ptr assignment from std::shared_ptr",
           "[weak_ptr][assignment]") {
@@ -18,7 +18,7 @@ TEST_CASE("weak_ptr assignment from std::shared_ptr",
 
 TEST_CASE("weak_ptr assignment from std::shared_ptr to derived class",
           "[weak_ptr][assignment]") {
-    auto p = std::make_shared<TestDerivedClass>(42);
+    auto p = std::make_shared<TestDerivedClass>();
     throwing::weak_ptr<TestBaseClass> wp;
     REQUIRE(wp.lock() == nullptr);
     wp = p;

--- a/tests/weak_ptr_construction.cpp
+++ b/tests/weak_ptr_construction.cpp
@@ -5,7 +5,7 @@
 
 #include "test_helpers.h"
 #include <catch.hpp>
-#include <throwing/weak_ptr.hpp>
+#include <throwing/shared_ptr.hpp>
 
 TEST_CASE("weak_ptr default constructor", "[weak_ptr][constructor]") {
     throwing::weak_ptr<int> null;
@@ -21,7 +21,7 @@ TEST_CASE("weak_ptr constructor from std::shared_ptr",
 
 TEST_CASE("weak_ptr constructor from std::shared_ptr to derived class",
           "[weak_ptr][constructor]") {
-    auto p = std::make_shared<TestDerivedClass>(42);
+    auto p = std::make_shared<TestDerivedClass>();
     throwing::weak_ptr<TestBaseClass> wp(p);
     REQUIRE(wp.lock() == p);
 }

--- a/tests/weak_ptr_construction.cpp
+++ b/tests/weak_ptr_construction.cpp
@@ -1,0 +1,71 @@
+//          Copyright Claudio Bantaloukas 2017-2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include "test_helpers.h"
+#include <catch.hpp>
+#include <throwing/weak_ptr.hpp>
+
+TEST_CASE("weak_ptr default constructor", "[weak_ptr][constructor]") {
+    throwing::weak_ptr<int> null;
+    REQUIRE(null.lock() == nullptr);
+}
+
+TEST_CASE("weak_ptr constructor from std::shared_ptr",
+          "[weak_ptr][constructor]") {
+    auto p = std::make_shared<int>(42);
+    throwing::weak_ptr<int> wp(p);
+    REQUIRE(wp.lock() == p);
+}
+
+TEST_CASE("weak_ptr constructor from std::shared_ptr to derived class",
+          "[weak_ptr][constructor]") {
+    auto p = std::make_shared<TestDerivedClass>(42);
+    throwing::weak_ptr<TestBaseClass> wp(p);
+    REQUIRE(wp.lock() == p);
+}
+
+TEST_CASE("weak_ptr constructor from throwing::shared_ptr",
+          "[weak_ptr][constructor]") {
+    auto p = throwing::make_shared<int>(42);
+    throwing::weak_ptr<int> wp(p);
+    REQUIRE(wp.lock() == p);
+}
+
+TEST_CASE("weak_ptr constructor from throwing::shared_ptr to derived class",
+          "[weak_ptr][constructor]") {
+    auto p = throwing::make_shared<TestDerivedClass>();
+    throwing::weak_ptr<TestBaseClass> wp(p);
+    REQUIRE(wp.lock() == p);
+}
+
+TEST_CASE("weak_ptr copy constructor", "[weak_ptr][constructor]") {
+    auto p = throwing::make_shared<int>(42);
+    throwing::weak_ptr<int> wp(p);
+    throwing::weak_ptr<int> wp2(wp);
+    REQUIRE(wp2.lock() == p);
+}
+
+TEST_CASE("weak_ptr copy constructor from derived class",
+          "[weak_ptr][constructor]") {
+    auto p = throwing::make_shared<TestDerivedClass>();
+    throwing::weak_ptr<TestDerivedClass> wp(p);
+    throwing::weak_ptr<TestBaseClass> wp2(wp);
+    REQUIRE(wp2.lock() == p);
+}
+
+TEST_CASE("weak_ptr move constructor", "[weak_ptr][constructor]") {
+    auto p = throwing::make_shared<int>(42);
+    throwing::weak_ptr<int> wp(p);
+    throwing::weak_ptr<int> wp2(std::move(wp));
+    REQUIRE(wp2.lock() == p);
+}
+
+TEST_CASE("weak_ptr move constructor from derived class",
+          "[weak_ptr][constructor]") {
+    auto p = throwing::make_shared<TestDerivedClass>();
+    throwing::weak_ptr<TestDerivedClass> wp(p);
+    throwing::weak_ptr<TestBaseClass> wp2(std::move(wp));
+    REQUIRE(wp2.lock() == p);
+}

--- a/tests/weak_ptr_modifiers.cpp
+++ b/tests/weak_ptr_modifiers.cpp
@@ -1,0 +1,48 @@
+//          Copyright Claudio Bantaloukas 2017-2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include "test_helpers.h"
+#include <catch.hpp>
+#include <throwing/weak_ptr.hpp>
+
+TEST_CASE("weak_ptr reset", "[weak_ptr][reset]") {
+    auto p = std::make_shared<int>(42);
+    throwing::weak_ptr<int> wp(p);
+    REQUIRE(wp.use_count() == 1);
+    REQUIRE(wp.expired() == false);
+    REQUIRE(wp.lock() == p);
+    wp.reset();
+    REQUIRE(wp.lock() == nullptr);
+}
+
+TEST_CASE("weak_ptr swap", "[weak_ptr][swap]") {
+    auto p1 = std::make_shared<int>(41);
+    auto p2 = std::make_shared<int>(42);
+    throwing::weak_ptr<int> wp1(p1);
+    throwing::weak_ptr<int> wp2(p2);
+    REQUIRE(wp1.lock() == p1);
+    REQUIRE(wp2.lock() == p2);
+    wp1.swap(wp2);
+    REQUIRE(wp1.lock() == p2);
+    REQUIRE(wp2.lock() == p1);
+    wp2.swap(wp1);
+    REQUIRE(wp1.lock() == p1);
+    REQUIRE(wp2.lock() == p2);
+}
+
+TEST_CASE("weak_ptr std::swap", "[weak_ptr][swap]") {
+    auto p1 = std::make_shared<int>(41);
+    auto p2 = std::make_shared<int>(42);
+    throwing::weak_ptr<int> wp1(p1);
+    throwing::weak_ptr<int> wp2(p2);
+    REQUIRE(wp1.lock() == p1);
+    REQUIRE(wp2.lock() == p2);
+    std::swap(wp1, wp2);
+    REQUIRE(wp1.lock() == p2);
+    REQUIRE(wp2.lock() == p1);
+    std::swap(wp1, wp2);
+    REQUIRE(wp1.lock() == p1);
+    REQUIRE(wp2.lock() == p2);
+}

--- a/tests/weak_ptr_modifiers.cpp
+++ b/tests/weak_ptr_modifiers.cpp
@@ -5,7 +5,7 @@
 
 #include "test_helpers.h"
 #include <catch.hpp>
-#include <throwing/weak_ptr.hpp>
+#include <throwing/shared_ptr.hpp>
 
 TEST_CASE("weak_ptr reset", "[weak_ptr][reset]") {
     auto p = std::make_shared<int>(42);

--- a/tests/weak_ptr_observers.cpp
+++ b/tests/weak_ptr_observers.cpp
@@ -1,0 +1,68 @@
+//          Copyright Claudio Bantaloukas 2017-2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include "test_helpers.h"
+#include <catch.hpp>
+#include <throwing/weak_ptr.hpp>
+
+TEST_CASE("weak_ptr use_count and expired", "[weak_ptr][use_count]") {
+    throwing::weak_ptr<int> wp;
+    REQUIRE(wp.use_count() == 0);
+    REQUIRE(wp.expired() == true);
+
+    wp = std::make_shared<int>(42);
+    REQUIRE(wp.use_count() == 0);
+    REQUIRE(wp.expired() == true);
+
+    auto p1 = std::make_shared<int>(42);
+    wp = p1;
+    REQUIRE(wp.use_count() == 1);
+    REQUIRE(wp.expired() == false);
+
+    auto p2 = p1;
+    REQUIRE(wp.use_count() == 2);
+    REQUIRE(wp.expired() == false);
+
+    p1.reset();
+    REQUIRE(wp.use_count() == 1);
+    REQUIRE(wp.expired() == false);
+
+    p2.reset();
+    REQUIRE(wp.use_count() == 0);
+    REQUIRE(wp.expired() == true);
+}
+
+TEST_CASE("weak_ptr lock creates throwing_ptr", "[weak_ptr][lock]") {
+    throwing::shared_ptr<TestBaseClass> p;
+    throwing::weak_ptr<TestBaseClass> wp;
+
+    REQUIRE(wp.lock() == nullptr);
+    REQUIRE_THROWS_AS(wp.lock()->dummy(), throwing::base_null_ptr_exception);
+
+    p = throwing::make_shared<TestBaseClass>();
+    wp = p;
+    wp.lock()->dummy(); // no exception
+
+    p.reset();
+    REQUIRE_THROWS_AS(wp.lock()->dummy(), throwing::base_null_ptr_exception);
+}
+
+TEST_CASE("weak_ptr owner_before behaves as std::weak_ptr",
+          "[weak_ptr][owner_before]") {
+    auto sp1 = std::make_shared<MemoryPositionHelper>(1, 2);
+    std::shared_ptr<int> sp2(sp1, &sp1->m1);
+    std::shared_ptr<int> sp3(sp1, &sp1->m2);
+    std::weak_ptr<int> sw2(sp2);
+    std::weak_ptr<int> sw3(sp3);
+
+    auto tsp1 = throwing::make_shared<MemoryPositionHelper>(1, 2);
+    throwing::shared_ptr<int> tsp2(tsp1, &tsp1->m1);
+    throwing::shared_ptr<int> tsp3(tsp1, &tsp1->m2);
+    throwing::weak_ptr<int> tw2(tsp2);
+    throwing::weak_ptr<int> tw3(tsp3);
+
+    REQUIRE(sw2.owner_before(sw3) == tw2.owner_before(tw3));
+    REQUIRE(sw3.owner_before(sw2) == tw3.owner_before(tw2));
+}

--- a/tests/weak_ptr_observers.cpp
+++ b/tests/weak_ptr_observers.cpp
@@ -39,14 +39,14 @@ TEST_CASE("weak_ptr lock creates throwing_ptr", "[weak_ptr][lock]") {
     throwing::weak_ptr<TestBaseClass> wp;
 
     REQUIRE(wp.lock() == nullptr);
-    REQUIRE_THROWS_AS(wp.lock()->dummy(), throwing::base_null_ptr_exception);
+    REQUIRE_THROWS_AS(wp.lock()->dummy(), throwing::base_null_ptr_exception&);
 
     p = throwing::make_shared<TestBaseClass>();
     wp = p;
     wp.lock()->dummy(); // no exception
 
     p.reset();
-    REQUIRE_THROWS_AS(wp.lock()->dummy(), throwing::base_null_ptr_exception);
+    REQUIRE_THROWS_AS(wp.lock()->dummy(), throwing::base_null_ptr_exception&);
 }
 
 TEST_CASE("weak_ptr owner_before behaves as std::weak_ptr",

--- a/tests/weak_ptr_observers.cpp
+++ b/tests/weak_ptr_observers.cpp
@@ -5,7 +5,7 @@
 
 #include "test_helpers.h"
 #include <catch.hpp>
-#include <throwing/weak_ptr.hpp>
+#include <throwing/shared_ptr.hpp>
 
 TEST_CASE("weak_ptr use_count and expired", "[weak_ptr][use_count]") {
     throwing::weak_ptr<int> wp;


### PR DESCRIPTION
the only difference is that throwing::weak_ptr::lock() returns a throwing::shared_ptr instead of a std::shared_ptr